### PR TITLE
fix: correct the `exclude` field in `typst.toml`

### DIFF
--- a/typst.toml
+++ b/typst.toml
@@ -9,4 +9,4 @@ categories = ["fun"]
 keywords = ["chat", "message"]
 homepage = "https://quadnucyard.github.io/ourchat-typ"
 repository = "https://github.com/QuadnucYard/ourchat-typ"
-exclude = ["./assets"]
+exclude = ["/assets/"]


### PR DESCRIPTION
Resolves #3

Please refer to https://github.com/typst/packages/issues/3617 for explanation.

Also, you can download [an unofficial build of the official package bundler](https://github.com/typst-community/dev-builds/releases/tag/packages-bundler-main.2025-12-10.8c2f3eb) and verify that it works.

```shell
just package
mkdir packages/preview/ourchat
mv out packages/preview/ourchat/0.2.2
./packages-bundler
cd ./dist/preview
7z x ourchat-0.2.2.tar.gz
mkdir ourchat/0.2.2 && cd ourchat/0.2.2
7z x .../ourchat-0.2.2.tar
cd ....
echo '#import "@preview/ourchat:0.2.2"' | TYPST_PACKAGE_CACHE_PATH=. typst compile - - --format svg
```